### PR TITLE
Update OpenRouter model name in testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ For testing other providers via OpenRouter:
 
 ```bash
 python tool_calls_eval.py samples.jsonl \
-    --model kimi-k2-0905-preview \
+    --model moonshotai/kimi-k2-0905 \
     --base-url https://openrouter.ai/api/v1 \
     --api-key YOUR_OPENROUTER_API_KEY \
     --concurrency 5 \


### PR DESCRIPTION
Current model name in readme will error:

```Error code: 400 - {'error': {'message': 'kimi-k2-0905-preview is not a valid model ID', 'code': 400}```

Suggested readme fix means it will now work with OpenRouter.